### PR TITLE
Refine selector tree connectors

### DIFF
--- a/src/app/components/RecipesSelector.tsx
+++ b/src/app/components/RecipesSelector.tsx
@@ -11,17 +11,13 @@ interface RecipesSelectorProps {
   stuff: string;
   recipes: IRecipe[];
   treePath: string[];
-  isLast?: boolean;
 }
-
-const marginleftClasses = ["ml-4", "ml-8", "ml-12", "ml-16", "ml-20", "ml-24"];
 
 export function RecipesSelector({
   rowId,
   stuff,
   recipes,
   treePath,
-  isLast = false,
 }: RecipesSelectorProps) {
   const selectedRecipe = useTreeSelectedRecipe(rowId, treePath);
   const dispatch = useAppDispatch();
@@ -30,58 +26,9 @@ export function RecipesSelector({
     dispatch(selectTreeRecipe({ rowId, recipe, treePath }));
   };
 
-  const marginleftClass =
-    marginleftClasses[
-      Math.min(treePath.length - 1, marginleftClasses.length - 1)
-    ];
-  const isNested = treePath.length > 1;
-  const treeDepth = treePath.length - 1;
-
-  // Enhanced positioning for clearer tree visualization
-  const connectorLeftPosition = treeDepth > 0 ? 2 + (treeDepth - 1) * 8 : 0;
-
-  // Calculate content padding to avoid overlap with connectors
-  const contentLeftPadding = isNested ? connectorLeftPosition + 16 : 0; // 16px = connector width + horizontal line + some margin
-
   return (
-    <div className={`relative panel-compact mb-1 ${marginleftClass}`}>
-      {/* Tree connector lines */}
-      {isNested && (
-        <>
-          {/* Vertical line for this level */}
-          <div
-            className="absolute tree-line"
-            style={{
-              left: `${connectorLeftPosition}px`,
-              top: "0px",
-              width: "2px",
-              height: isLast ? "50%" : "100%",
-              backgroundColor: "var(--border-600)",
-              opacity: "0.6",
-            }}
-          ></div>
-          {/* Horizontal connector from parent to current item */}
-          <div
-            className="absolute tree-line"
-            style={{
-              left: `${connectorLeftPosition}px`,
-              top: "50%",
-              width: "12px",
-              height: "2px",
-              backgroundColor: "var(--border-600)",
-              opacity: "0.8",
-              transform: "translateY(-1px)",
-            }}
-          ></div>
-        </>
-      )}
-      <div
-        className="relative z-10"
-        style={{
-          paddingLeft:
-            contentLeftPadding > 0 ? `${contentLeftPadding}px` : undefined,
-        }}
-      >
+    <div className="relative z-10 panel-compact mb-1">
+      <div className="relative z-10">
         <span className="font-medium text-sm tracking-wide text-muted-300">
           {stuff}
         </span>

--- a/src/app/components/SelectorTree.tsx
+++ b/src/app/components/SelectorTree.tsx
@@ -15,24 +15,44 @@ export function SelectorTree({
   treePath,
   isLast = false,
 }: SelectorTreeProps) {
+  const depth = treePath.length - 1;
+  const isRoot = depth === 0;
+  const hasChildren = recipesTree.required.length > 0;
+  const wrapperClassNames = [
+    "tree-node",
+    isRoot ? "tree-node--root" : "",
+    isLast ? "tree-node--last" : "",
+    hasChildren ? "tree-node--branch" : "tree-node--leaf",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <>
-      <RecipesSelector
-        rowId={rowId}
-        stuff={recipesTree.stuff}
-        recipes={recipesTree.recipes}
-        treePath={treePath}
-        isLast={isLast}
-      />
-      {recipesTree.required.map((e, index) => (
-        <SelectorTree
-          key={e.stuff}
+    <div
+      className={wrapperClassNames}
+      style={{ "--tree-depth": depth } as React.CSSProperties}
+    >
+      <div className="tree-node__content">
+        <RecipesSelector
           rowId={rowId}
-          recipesTree={e}
-          treePath={[...treePath, e.stuff]}
-          isLast={index === recipesTree.required.length - 1}
+          stuff={recipesTree.stuff}
+          recipes={recipesTree.recipes}
+          treePath={treePath}
         />
-      ))}
-    </>
+      </div>
+      {hasChildren && (
+        <div className="tree-node__children">
+          {recipesTree.required.map((e, index) => (
+            <SelectorTree
+              key={e.stuff}
+              rowId={rowId}
+              recipesTree={e}
+              treePath={[...treePath, e.stuff]}
+              isLast={index === recipesTree.required.length - 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,24 +119,56 @@ body.app-body {
   }
 
   /* Tree visualization styles */
-  .tree-connector {
-    @apply absolute text-xs font-mono leading-none select-none;
-    color: var(--border-600);
+  .tree-node {
+    position: relative;
+    --tree-depth: 0;
+    --tree-indent-step: 1rem;
+    --tree-gutter: 1.5rem;
+    --tree-spine-offset: calc(var(--tree-gutter) / 2);
+    --tree-elbow-y: 1.4rem;
+    margin-left: calc(var(--tree-depth) * var(--tree-indent-step));
+    padding-left: var(--tree-gutter);
   }
 
-  .tree-line {
-    @apply absolute;
+  .tree-node--root {
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  .tree-node:not(.tree-node--root)::before,
+  .tree-node:not(.tree-node--root)::after {
+    content: "";
+    position: absolute;
+    left: var(--tree-spine-offset);
     background-color: var(--border-600);
-    opacity: 0.4;
+    pointer-events: none;
   }
 
-  .tree-line-vertical {
-    @apply tree-line;
+  .tree-node:not(.tree-node--root)::before {
+    top: 0;
+    bottom: 0;
     width: 1px;
+    opacity: 0.45;
   }
 
-  .tree-line-horizontal {
-    @apply tree-line;
+  .tree-node:not(.tree-node--root)::after {
+    top: var(--tree-elbow-y);
+    width: calc(var(--tree-gutter) - var(--tree-spine-offset));
     height: 1px;
+    opacity: 0.6;
+  }
+
+  .tree-node--last.tree-node--leaf::before {
+    bottom: auto;
+    height: var(--tree-elbow-y);
+  }
+
+  .tree-node__content {
+    position: relative;
+    z-index: 1;
+  }
+
+  .tree-node__children {
+    margin-top: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- wrap each recipe selector level in a dedicated tree-node container so connectors can surround nested subtrees
- simplify RecipesSelector markup now that indentation and connectors are handled by the wrapper
- add CSS rules that draw vertical spines and horizontal elbows for the recipe tree

## Testing
- npm run lint
- npm run test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cd500e771c8320a02d538217e664b6